### PR TITLE
fix: A classical Heisenberg bug: Sporadic test fails on ~1/3 tests on various Python envs (3.11/3.12/3.13)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ class ServerFixture:
 
 def wait_for_server(url, timeout=10):
     session = requests.Session()
-    session.mount("http://", HTTPAdapter(max_retries=Retry(total=20, backoff_factor=0.05)))
+    session.mount("http://", HTTPAdapter(max_retries=Retry(total=40, backoff_factor=0.1, backoff_max=1)))
     session.get(url, timeout=timeout)
 
 


### PR DESCRIPTION
Fixes #40

### Summary
This PR addresses [A classical Heisenberg bug: Sporadic test fails on ~1/3 tests on various Python envs (3.11/3.12/3.13)](https://github.com/Nayjest/lm-proxy/issues/40).

### Changes
```
 tests/conftest.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

```

### Testing
- Existing test suite was run after applying changes
- Manual review of diff for correctness

---
<sub>If this fix isn't quite right, please leave feedback and I'll revise it.</sub>
