### PR TITLE
Fix logger class reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ api_keys = [
 [[loggers]]
 class = 'lm_proxy.loggers.BaseLogger'
 [loggers.log_writer]
-class = 'lm_proxy.loggers.log_writers.JsonLogWriter'
+class = 'lm_proxy.loggers.JsonLogWriter'
 file_name = 'storage/json.log'
 [loggers.entry_transformer]
 class = 'lm_proxy.loggers.LogEntryTransformer'


### PR DESCRIPTION
Fix for:

uvx lm-proxy
18:55:10 INFO: Bootstrapping LM-Proxy...
  - Config......[ config.toml ]
  - Env. File...[ .env ] 18:55:10 ERROR: Can't resolve callable by name 'lm_proxy.loggers.log_writers.JsonLogWriter', No module named 'lm_proxy.loggers.log_writers'; 'lm_proxy.loggers' is not a package