### PR TITLE
Update GitHub Actions workflows and README for coverage badge handling

### DIFF
--- a/.github/workflows/tests.reusable.yml
+++ b/.github/workflows/tests.reusable.yml
@@ -8,12 +8,17 @@ on:
         type: string
       update-badge:
         type: boolean
-        description: Publish coverage.svg to branch coverage-badge (caller sets for push to main only).
         default: false
       skip-ci:
         type: boolean
         description: Skip tests when caller detects [skip ci] on push (caller computes from head commit).
         default: false
+      environment:
+        type: string
+        description: |
+          GitHub Actions environment to enforce deployment protection rules.
+          Use 'external-pr' for untrusted external PRs to require maintainer approval
+          before accessing secrets, preventing malicious code from exfiltrating credentials.
     secrets:
       OPENAI_API_KEY:
         description: Available when repo secrets are exposed to the workflow (not on fork pull_request).
@@ -26,6 +31,8 @@ jobs:
   test:
     if: ${{ !inputs.skip-ci }}
     runs-on: ubuntu-latest
+    # Enforces GitHub Actions environment protection rules (manual approval for external PRs)
+    environment: ${{ inputs.environment }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -48,14 +55,23 @@ jobs:
         pip install poetry
         poetry install -E test
         echo "$(poetry env info --path)/bin" >> $GITHUB_PATH
-    - name: Test with pytest
-      if: matrix.python-version != '3.13'
+    # Keep fork PRs secret-free: tests run without API keys when external-pr environment is used.
+    - name: Test with pytest (external PR - no secrets)
+      if: matrix.python-version != '3.13' && inputs.environment == 'external-pr'
+      run: |
+        pytest
+    - name: Test with pytest (trusted - with secrets)
+      if: matrix.python-version != '3.13' && inputs.environment != 'external-pr'
       env:
         LLM_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
         pytest
-    - name: Test with pytest +coverage
-      if: matrix.python-version == '3.13'
+    - name: Test with pytest +coverage (external PR - no secrets)
+      if: matrix.python-version == '3.13' && inputs.environment == 'external-pr'
+      run: |
+        pytest --cov=lm_proxy --cov-report=xml
+    - name: Test with pytest +coverage (trusted - with secrets)
+      if: matrix.python-version == '3.13' && inputs.environment != 'external-pr'
       env:
         LLM_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
@@ -68,19 +84,10 @@ jobs:
     - name: Validate coverage badge output
       if: matrix.python-version == '3.13' && inputs.update-badge
       run: |
-        python3 <<'PY'
-        import os, sys
-        p = "coverage.svg"
-        if not os.path.isfile(p):
-            sys.exit("coverage.svg missing")
-        n = os.path.getsize(p)
-        if n < 120:
-            sys.exit(f"coverage.svg too small ({n} bytes), genbadge likely failed silently")
-        with open(p, "rb") as f:
-            head = f.read(4096)
-        if b"<svg" not in head.lower():
-            sys.exit("coverage.svg does not start with an SVG document")
-        PY
+        f=coverage.svg
+        s=$(wc -c < "$f" 2>/dev/null) || s=0
+        [ "$s" -ge 120 ] || { echo "$f missing or too small ($s B)"; exit 1; }
+        head -c 4096 "$f" | grep -qiF '<svg' || { echo "$f: not an SVG"; exit 1; }
     - name: Upload coverage badge artifact
       if: success() && matrix.python-version == '3.13' && inputs.update-badge
       uses: actions/upload-artifact@v4
@@ -90,33 +97,34 @@ jobs:
         if-no-files-found: error
         retention-days: 1
 
-  # Isolated job: token write only here. Runs only when update-badge is true (push main), skip-ci false,
-  # and matrix job test fully succeeded (fail-fast false ⇒ any failing matrix leg ⇒ needs.test ≠ success).
+  # Isolated job: token write only for publishing coverage-badge branch.
   update-coverage-badge:
     needs: test
-    if: ${{ inputs.update-badge && !inputs.skip-ci && needs.test.result == 'success' }}
+    if: >-
+      inputs.update-badge
+      && !inputs.skip-ci
+      && needs.test.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write
     steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: coverage-badge
+        fetch-depth: 1
+        token: ${{ secrets.GITHUB_TOKEN }}
+        # persist-credentials intentionally true (default) - git push relies on it
     - uses: actions/download-artifact@v4
       with:
         name: coverage-badge
         path: badge
     - name: Push coverage.svg to orphan branch coverage-badge
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        set -e
-        gh auth setup-git
-        mkdir -p /tmp/coverage-badge-publish
-        cd /tmp/coverage-badge-publish
-        git init
+        set -euo pipefail
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
-        cp "${GITHUB_WORKSPACE}/badge/coverage.svg" .
+        cp badge/coverage.svg coverage.svg
         git add coverage.svg
-        git commit -m "Update coverage badge [skip ci]"
-        git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-        git push -f origin HEAD:coverage-badge
+        git diff --cached --quiet || git commit -m "Update coverage badge [skip ci]"
+        git push origin HEAD:coverage-badge

--- a/.github/workflows/tests.reusable.yml
+++ b/.github/workflows/tests.reusable.yml
@@ -8,22 +8,27 @@ on:
         type: string
       update-badge:
         type: boolean
+        description: Publish coverage.svg to branch coverage-badge (caller sets for push to main only).
         default: false
-      environment:
-        type: string
-        description: |
-          GitHub Actions environment to enforce deployment protection rules.
-          Use 'external-pr' for untrusted external PRs to require maintainer approval
-          before accessing secrets, preventing malicious code from exfiltrating credentials.
+      skip-ci:
+        type: boolean
+        description: Skip tests when caller detects [skip ci] on push (caller computes from head commit).
+        default: false
+    secrets:
+      OPENAI_API_KEY:
+        description: Available when repo secrets are exposed to the workflow (not on fork pull_request).
+        required: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   test:
+    if: ${{ !inputs.skip-ci }}
     runs-on: ubuntu-latest
-    # Enforces GitHub Actions environment protection rules (manual approval for external PRs)
-    environment: ${{ inputs.environment }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +38,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.ref }}
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
@@ -59,13 +65,58 @@ jobs:
       run: |
         pip install genbadge[coverage]
         genbadge coverage -i coverage.xml -o coverage.svg
-    - name: Commit coverage badge
+    - name: Validate coverage badge output
       if: matrix.python-version == '3.13' && inputs.update-badge
       run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add coverage.svg
-        git commit -m "Update coverage badge [skip ci]" || echo "No changes to commit"
-        git push
+        python3 <<'PY'
+        import os, sys
+        p = "coverage.svg"
+        if not os.path.isfile(p):
+            sys.exit("coverage.svg missing")
+        n = os.path.getsize(p)
+        if n < 120:
+            sys.exit(f"coverage.svg too small ({n} bytes), genbadge likely failed silently")
+        with open(p, "rb") as f:
+            head = f.read(4096)
+        if b"<svg" not in head.lower():
+            sys.exit("coverage.svg does not start with an SVG document")
+        PY
+    - name: Upload coverage badge artifact
+      if: success() && matrix.python-version == '3.13' && inputs.update-badge
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-badge
+        path: coverage.svg
+        if-no-files-found: error
+        retention-days: 1
+
+  # Isolated job: token write only here. Runs only when update-badge is true (push main), skip-ci false,
+  # and matrix job test fully succeeded (fail-fast false ⇒ any failing matrix leg ⇒ needs.test ≠ success).
+  update-coverage-badge:
+    needs: test
+    if: ${{ inputs.update-badge && !inputs.skip-ci && needs.test.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: coverage-badge
+        path: badge
+    - name: Push coverage.svg to orphan branch coverage-badge
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -e
+        gh auth setup-git
+        mkdir -p /tmp/coverage-badge-publish
+        cd /tmp/coverage-badge-publish
+        git init
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        cp "${GITHUB_WORKSPACE}/badge/coverage.svg" .
+        git add coverage.svg
+        git commit -m "Update coverage badge [skip ci]"
+        git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+        git push -f origin HEAD:coverage-badge

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,33 +5,16 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  pull_request_target:
-    branches: [ "main" ]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  test-trusted-src:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+  ci:
     uses: ./.github/workflows/tests.reusable.yml
     with:
       ref: ${{ github.ref }}
       update-badge: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    secrets: inherit
-
-  test-fork-pr:
-    if: |
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository
-    uses: ./.github/workflows/tests.reusable.yml
-    with:
-      ref: ${{ github.event.pull_request.head.sha }}
-      # "external-pr" GitHub env. requires workflow execution approval by maintainers
-      # to mitigate exfiltration attacks via malicious PR code.
-      # (!) Always carefully review external PRs before approving workflow runs.
-      # Blocks exfiltration attacks via malicious PR code
-      environment: external-pr
-    secrets: inherit  # Required for passing secrets to reusable workflow.
+      skip-ci: ${{ github.event_name == 'push' && contains(github.event.head_commit.message, '[skip ci]') }}
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,17 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  pull_request_target:
+    branches: [ "main" ]
 
 permissions:
   contents: read
 
 jobs:
-  ci:
+  test-trusted-src:
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/tests.reusable.yml
     with:
       ref: ${{ github.ref }}
@@ -18,3 +23,18 @@ jobs:
       skip-ci: ${{ github.event_name == 'push' && contains(github.event.head_commit.message, '[skip ci]') }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+  test-fork-pr:
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    uses: ./.github/workflows/tests.reusable.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      # "external-pr" GitHub env. requires workflow execution approval by maintainers
+      # to mitigate exfiltration attacks via malicious PR code.
+      # (!) Always carefully review external PRs before approving workflow runs.
+      # Blocks exfiltration attacks via malicious PR code
+      environment: external-pr
+      skip-ci: false
+    # No secrets on fork PRs: reusable workflow handles this path without API keys.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs
 !.aico/project.json
 .coverage
 coverage.xml
+coverage.svg

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://pypi.org/project/lm-proxy/"><img src="https://img.shields.io/pypi/v/lm-proxy?color=blue" alt="PyPI"></a>
   <a href="https://github.com/Nayjest/lm-proxy/actions/workflows/tests.yml"><img src="https://github.com/Nayjest/lm-proxy/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
   <a href="https://github.com/Nayjest/lm-proxy/actions/workflows/code-style.yml"><img src="https://github.com/Nayjest/lm-proxy/actions/workflows/code-style.yml/badge.svg" alt="Code Style"></a>
-  <img src="https://raw.githubusercontent.com/Nayjest/lm-proxy/main/coverage.svg" alt="Code Coverage">
+  <img src="https://raw.githubusercontent.com/Nayjest/lm-proxy/coverage-badge/coverage.svg" alt="Code Coverage">
   <a href="https://www.bestpractices.dev/projects/11364"><img src="https://www.bestpractices.dev/projects/11364/badge"></a>
   <br>
   <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/README.md"><img src="https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/refs/heads/main/badges/StandWithUkraine.svg" alt="Stand With Ukraine"></a>

--- a/tests/test_api_key_check_with_request.py
+++ b/tests/test_api_key_check_with_request.py
@@ -1,0 +1,49 @@
+import requests
+
+from lm_proxy.api_key_check import CheckAPIKeyWithRequest
+
+
+class _ResponseOk:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_check_api_key_with_request_success(monkeypatch):
+    def fake_request(method, url, headers, timeout):
+        assert method == "post"
+        assert url == "https://auth.local/check?key=token-1"
+        assert headers["Authorization"] == "Bearer token-1"
+        assert timeout == 3
+        return _ResponseOk({"group": "pro", "sub": "u-1"})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+
+    checker = CheckAPIKeyWithRequest(
+        url="https://auth.local/check?key={api_key}",
+        method="post",
+        headers={"Authorization": "Bearer {api_key}"},
+        timeout=3,
+        response_as_user_info=True,
+        group_field="group",
+        default_group="default",
+    )
+
+    group, user_info = checker("token-1")
+    assert group == "pro"
+    assert user_info == {"group": "pro", "sub": "u-1"}
+
+
+def test_check_api_key_with_request_returns_none_on_http_error(monkeypatch):
+    def fake_request(*args, **kwargs):
+        raise requests.exceptions.RequestException("boom")
+
+    monkeypatch.setattr(requests, "request", fake_request)
+
+    checker = CheckAPIKeyWithRequest(url="https://auth.local/check?key={api_key}")
+    assert checker("token-2") is None


### PR DESCRIPTION
- Added coverage.svg to .gitignore.
- Updated README to reference the new coverage badge URL.
- Enhanced tests workflow to include a validation step for coverage.svg and upload it as an artifact.
- Refactored reusable tests workflow to improve permissions and skip CI logic.