### PR TITLE
fix: keep JsonLogWriter file handle open across writes

### DIFF
--- a/lm_proxy/loggers.py
+++ b/lm_proxy/loggers.py
@@ -73,7 +73,13 @@ class BaseLogger:
 
 @dataclass
 class JsonLogWriter(AbstractLogWriter):
-    """Writes logged data to a JSON file."""
+    """Writes logged data to a JSON file.
+
+    Keeps a single file handle open for the lifetime of the writer instead of
+    opening and closing it on every write.  This avoids the repeated open/close
+    syscall overhead, which is noticeable when many requests are logged in quick
+    succession.
+    """
 
     file_name: str
 
@@ -81,13 +87,21 @@ class JsonLogWriter(AbstractLogWriter):
         dir_path = os.path.dirname(self.file_name)
         if dir_path:
             os.makedirs(dir_path, exist_ok=True)
-        # Create the file if it doesn't exist
-        with open(self.file_name, "a", encoding="utf-8"):
-            pass
+        # Open once; reuse the handle for all subsequent writes.
+        self._file = open(self.file_name, "a", encoding="utf-8")  # noqa: SIM115
 
     def __call__(self, logged_data: dict):
-        with open(self.file_name, "a", encoding="utf-8") as f:
-            f.write(json.dumps(logged_data, cls=CustomJsonEncoder) + "\n")
+        self._file.write(json.dumps(logged_data, cls=CustomJsonEncoder) + "\n")
+        self._file.flush()
+
+    def close(self) -> None:
+        """Flush and close the underlying file handle."""
+        if hasattr(self, "_file") and not self._file.closed:
+            self._file.flush()
+            self._file.close()
+
+    def __del__(self) -> None:
+        self.close()
 
 
 TLogger = Union[BaseLogger, Callable[[RequestContext], None]]

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -69,3 +69,32 @@ async def test_json(tmp_path):
         log_data = json.loads(lines[0])
         assert log_data["request"]["model"] == "gpt-3.5-turbo"
         assert log_data["response"] == "Test response message"
+
+
+def test_json_writer_reuses_file_handle(tmp_path):
+    """JsonLogWriter should keep one file handle open across multiple writes."""
+    from lm_proxy.loggers import JsonLogWriter
+
+    log_file = tmp_path / "reuse_test.log"
+    writer = JsonLogWriter(file_name=str(log_file))
+
+    # File handle should be open after construction
+    assert not writer._file.closed
+
+    writer({"event": "first"})
+    writer({"event": "second"})
+
+    # Handle remains open between writes
+    assert not writer._file.closed
+
+    # Explicit close works
+    writer.close()
+    assert writer._file.closed
+
+    # Double-close is safe
+    writer.close()
+
+    lines = log_file.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["event"] == "first"
+    assert json.loads(lines[1])["event"] == "second"


### PR DESCRIPTION
## What

`JsonLogWriter.__call__` previously opened and closed the log file on every single invocation. This PR replaces that with a persistent handle opened once in `__post_init__`, plus a `close()` method and `__del__` finalizer for cleanup.

## Why

Every write paid two extra syscalls — `open` and `close` — regardless of how frequently requests arrive. Under moderate load (e.g. 100 req/s) this adds up quickly and is entirely avoidable since the file path never changes between calls.

Each write still calls `flush()` immediately, so data is visible to external readers (tail, log shippers) right away — the same durability guarantee as before, just without the per-call open/close overhead.

This was reported in #8.

## Changes

- `lm_proxy/loggers.py`: open the file once in `__post_init__`; write + flush in `__call__`; add `close()` and `__del__`
- `tests/test_loggers.py`: add `test_json_writer_reuses_file_handle` to verify the handle stays open between writes, that `close()` works, and that double-close is safe

Fixes #8