### PR TITLE
Fix: load configuration files starting with a UTF-8 BOM

### DIFF
--- a/lm_proxy/config_loaders/json.py
+++ b/lm_proxy/config_loaders/json.py
@@ -5,5 +5,7 @@ import json
 
 def load_json_config(config_path: str) -> dict:
     """Loads configuration from a JSON file."""
-    with open(config_path, "r", encoding="utf-8") as f:
+    # utf-8-sig skips the byte order mark that Windows text editors may add,
+    # the JSON parser rejects it
+    with open(config_path, "r", encoding="utf-8-sig") as f:
         return json.load(f)

--- a/lm_proxy/config_loaders/toml.py
+++ b/lm_proxy/config_loaders/toml.py
@@ -5,5 +5,7 @@ import tomllib
 
 def load_toml_config(config_path: str) -> dict:
     """Loads configuration from a TOML file."""
-    with open(config_path, "rb") as f:
-        return tomllib.load(f)
+    # utf-8-sig skips the byte order mark that Windows text editors may add,
+    # tomllib rejects it
+    with open(config_path, "r", encoding="utf-8-sig") as f:
+        return tomllib.loads(f.read())

--- a/tests/test_config_loaders.py
+++ b/tests/test_config_loaders.py
@@ -26,3 +26,15 @@ def test_config_loaders():
     # Expect an error for unsupported format
     with pytest.raises(ValueError):
         Config.load(root / "configs" / "test_config.xyz")
+
+
+def test_config_loaders_ignore_byte_order_mark(tmp_path):
+    """Configuration files saved by Windows text editors may start with a UTF-8 BOM."""
+    root = Path(__file__).resolve().parent
+    dotenv.load_dotenv(root.parent / ".env.template", override=True)
+    expected = Config.load(root / "configs" / "test_config.toml").model_dump()
+
+    for file_name in ("test_config.toml", "test_config.json", "test_config.yml"):
+        config_path = tmp_path / file_name
+        config_path.write_bytes(b"\xef\xbb\xbf" + (root / "configs" / file_name).read_bytes())
+        assert Config.load(config_path).model_dump() == expected, file_name


### PR DESCRIPTION
Closes #79

## Problem

A config file starting with a UTF-8 byte order mark (`EF BB BF`) fails to load with `TOMLDecodeError: Invalid statement (at line 1, column 1)`, even though the file is valid TOML. PowerShell redirection, `Set-Content`, `Out-File` and Notepad all produce such files by default on Windows.

## Fix

Read TOML and JSON configs with the `utf-8-sig` codec, which strips the BOM when present and is identical to `utf-8` when it is not.

Verified which loaders are actually affected before changing anything:

| format | with BOM, before |
|---|---|
| `.toml` | `TOMLDecodeError: Invalid statement (at line 1, column 1)` |
| `.json` | `JSONDecodeError: Unexpected UTF-8 BOM (decode using utf-8-sig)` |
| `.yml` | loads fine — PyYAML skips the BOM |
| `.py` | loads fine — the Python tokenizer skips the BOM |

So only `toml.py` and `json.py` are touched.

`tomllib.load()` requires a binary file object and therefore cannot be given an encoding, so the TOML loader now reads the text itself and calls `tomllib.loads()`.

## Verification

`test_config_loaders_ignore_byte_order_mark` prepends a BOM to each of the existing `.toml` / `.json` / `.yml` test configs and asserts all three still produce the same `Config` as the unmodified file.

```
python -m pytest -q     ->  4 failed, 26 passed
```

The 4 failures are pre-existing and unrelated: `tests/test_integration.py` calls the real OpenAI API and the `.env` in this working environment holds a placeholder key. `flake8 .` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
