### PR TITLE
fix: build versioned Docker images when a GitHub release is published

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,12 +5,13 @@ name: Docker
 #   - docker.io/lmproxy/lmproxy -- only when the
 #     DOCKERHUB_TOKEN repository secret is configured.
 #
-# Invoked by the release workflow (release.yml) when a release is published
+# Runs when a GitHub release is published
 # (producing X.Y.Z, X.Y, X and latest tags from the release tag "vX.Y.Z");
 # pushes to main produce "edge".
 
 on:
-  workflow_call:
+  release:
+    types: [ published ]
   push:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

`docker run lmproxy/lmproxy:3.3.0` fails because versioned images were never built: [docker.yml](.github/workflows/docker.yml) referenced a `release.yml` workflow that was never committed, so the only triggers were pushes to `main` (producing `edge`) and manual dispatch. The semver tags (`X.Y.Z`, `X.Y`, `X`, `latest`) from `metadata-action` require running on a version tag ref, which never happened.

## Fix

- Trigger the workflow directly on `release: [published]` — the release tag ref (`vX.Y.Z`) makes `metadata-action` emit `X.Y.Z`, `X.Y`, `X` and `latest` for both `ghcr.io/nayjest/lm-proxy` and `docker.io/lmproxy/lmproxy`.
- Remove the unused `workflow_call` trigger and fix the stale comment.

Closes #70

## Note for the v3.3.0 release

Release workflows run from the workflow file at the tagged commit, so the `v3.3.0` tag must point at a commit that includes this fix (i.e. tag after this PR merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)